### PR TITLE
Drone company show 드론 업체 조회 API 구현

### DIFF
--- a/src/main/java/com/drop/dropshop/droneCompany/controller/DroneCompanyController.java
+++ b/src/main/java/com/drop/dropshop/droneCompany/controller/DroneCompanyController.java
@@ -3,18 +3,22 @@ package com.drop.dropshop.droneCompany.controller;
 import com.drop.dropshop.droneCompany.dto.DroneCompanyDto;
 import com.drop.dropshop.droneCompany.entity.DroneCompany;
 import com.drop.dropshop.droneCompany.exception.BusinessNumberNotValidException;
+import com.drop.dropshop.droneCompany.response.PagingResponseDetails;
 import com.drop.dropshop.droneCompany.response.ResponseDetails;
 import com.drop.dropshop.droneCompany.service.DroneCompanyService;
 import com.drop.dropshop.droneCompany.util.HttpStatusChangeInt;
 import io.swagger.annotations.ApiOperation;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.Date;
+import java.util.List;
 
 @RestController
 @Slf4j
@@ -27,11 +31,26 @@ public class DroneCompanyController {
 
     @PostMapping("/api/drone-companies")
     @ApiOperation(value = "드론 업체 등록", notes = "관리자가 드론 업체를 등록합니다.")
-    public ResponseEntity<?> createCourse(@RequestBody DroneCompanyDto requestDto) throws BusinessNumberNotValidException {
+    public ResponseEntity<?> createDroneCompany(@RequestBody DroneCompanyDto requestDto) throws BusinessNumberNotValidException {
         DroneCompany droneCompany = droneCompanyService.join(requestDto);
         String path = "/api/drone-companies?id=" + droneCompany.getCompanyId();
         int httpStatus = HttpStatusChangeInt.ChangeStatusCode("CREATED");
         ResponseDetails responseDetails = new ResponseDetails(new Date(), droneCompany, httpStatus, path);
         return new ResponseEntity<>(responseDetails, HttpStatus.CREATED);
+    }
+
+    @GetMapping("/api/drone-companies")
+    @ApiOperation(value = "드론 업체 리스트 조회", notes = "관리자가 드론 업체를 조회합니다.")
+    public ResponseEntity<?> showAllDroneCompany(@PageableDefault(page = 1, size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        Page<DroneCompany> droneCompanyList = droneCompanyService.show(pageable);
+        int httpStatus = HttpStatusChangeInt.ChangeStatusCode("OK");
+        String path = "/api/drone-companies";
+        PagingResponseDetails pagingResponseDetails = new PagingResponseDetails(new Date(),
+                droneCompanyList.getContent(),
+                droneCompanyList.getTotalElements(),
+                droneCompanyList.getPageable().getPageNumber() + 1,
+                droneCompanyList.getPageable().getPageSize(),
+                httpStatus, path);
+        return new ResponseEntity<>(pagingResponseDetails, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/drop/dropshop/droneCompany/entity/DroneCompany.java
+++ b/src/main/java/com/drop/dropshop/droneCompany/entity/DroneCompany.java
@@ -35,7 +35,7 @@ public class DroneCompany extends Timestamped {
     private String loginId;
 
     @ApiModelProperty(example = "드론 업체가 로그인 시 사용할 password")
-    @Column(nullable = false, unique = true, length = 20)
+    @Column(nullable = false, length = 20)
     private String loginPassword;
 
     @ApiModelProperty(example = "드론 업체명")

--- a/src/main/java/com/drop/dropshop/droneCompany/response/PagingResponseDetails.java
+++ b/src/main/java/com/drop/dropshop/droneCompany/response/PagingResponseDetails.java
@@ -1,0 +1,18 @@
+package com.drop.dropshop.droneCompany.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Date;
+
+@Getter
+@AllArgsConstructor
+public class PagingResponseDetails {
+    private Date timestamp;
+    private Object data;
+    private Long total;
+    private int currentPage;
+    private int currentPageSize;
+    private int httpStatus;
+    private String path;
+}

--- a/src/main/java/com/drop/dropshop/droneCompany/service/DroneCompanyService.java
+++ b/src/main/java/com/drop/dropshop/droneCompany/service/DroneCompanyService.java
@@ -7,10 +7,14 @@ import com.drop.dropshop.droneCompany.exception.ErrorCode;
 import com.drop.dropshop.droneCompany.repository.DroneCompanyRepository;
 import okhttp3.*;
 import org.json.JSONObject;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.config.PageableHandlerMethodArgumentResolverCustomizer;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
 import java.io.IOException;
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -40,7 +44,6 @@ public class DroneCompanyService {
         try {
             Response response = client.newCall(request).execute();
             String responseBody = response.body().string();
-            System.out.println(responseBody);
             JSONObject jsonObject = new JSONObject(responseBody);
             if (jsonObject.has("match_cnt")) {
                 return true;
@@ -109,5 +112,12 @@ public class DroneCompanyService {
         return droneCompany;
     }
 
-
+    /**
+     * 드론 업체 조회
+     * 등록 일시를 기준으로 정렬하도록 하였습니다.
+     * 기본값 : page = 1, pageSize = 10, sort = createAt DESC
+     */
+    public Page<DroneCompany> show(Pageable pageable) {
+        return droneCompanyRepository.findAll(pageable);
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,11 @@ spring:
   mvc:
     pathmatch:
       matching-strategy: ant_path_matcher
+  data:
+    web:
+      pageable:
+        default-page-size: 10
+        one-indexed-parameters: true
 
 logging.level:
   org.hibernate.SQL: debug

--- a/src/test/java/com/drop/dropshop/droneCompany/service/DroneCompanyServiceTest.java
+++ b/src/test/java/com/drop/dropshop/droneCompany/service/DroneCompanyServiceTest.java
@@ -8,11 +8,17 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import static org.assertj.core.api.Assertions.assertThat;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
+@Transactional
 class DroneCompanyServiceTest {
     @Autowired
     private DroneCompanyRepository droneCompanyRepository;
@@ -51,6 +57,20 @@ class DroneCompanyServiceTest {
                 "3098106517"
         );
         DroneCompany droneCompany = droneCompanyService.join(droneCompanyDto);
+        assertEquals(droneCompanyDto.getCompanyName(), droneCompany.getCompanyName());
+    }
+
+    @Test
+    void 드론_업체_조회() throws BusinessNumberNotValidException {
+        DroneCompanyDto droneCompanyDto = new DroneCompanyDto(
+                "11드론",
+                "0313327312",
+                "3098106517"
+        );
+        DroneCompany droneCompany = droneCompanyService.join(droneCompanyDto);
+        Pageable pageable =  PageRequest.of(0, 10, Sort.by("createdAt").descending());
+        Page<DroneCompany> droneCompanies = droneCompanyService.show(pageable);
+        droneCompany = droneCompanies.getContent().get(0);
         assertEquals(droneCompanyDto.getCompanyName(), droneCompany.getCompanyName());
     }
 }


### PR DESCRIPTION
**구현 내용**
* 드론 업체 조회 API 를 개발하였습니다.
* 페이징 기능을 추가하였습니다. 
   * 기본 페이지 : 1
   * 기본 페이지 사이즈 : 10
   * 기본 정렬 : createdAt 컬럼을 기준으로 DESC
-------------------
**IntelliJ 에서 API 요청 시**
```
OkHttpClient client = new OkHttpClient().newBuilder().build();
MediaType mediaType = MediaType.parse("text/plain");
RequestBody body = RequestBody.create(mediaType, "");
Request request = new Request.Builder()
  .url("127.0.0.1:8080/api/drone-companies?page=1&pageSize=10&sort=id,desc")
  .method("GET", body)
  .build();
Response response = client.newCall(request).execute();
```
---------------
**postman 사용 시**
GET 127.0.0.1:8080/api/drone-companies?page=1&pageSize=10&sort=id,desc

---------------
**API 테스트**
<img width="874" alt="스크린샷 2022-06-07 오후 9 15 58" src="https://user-images.githubusercontent.com/84092014/172376523-a6bdb85c-df8a-4af3-be60-6ad361c38ded.png">

--------------
**Junit 테스트 결과 화면** 
<img width="1366" alt="스크린샷 2022-06-07 오후 9 17 54" src="https://user-images.githubusercontent.com/84092014/172376930-c593f267-ae42-4ae4-8051-24069f05885b.png">

