### PR TITLE
Drone company delete 드론 업체 삭제 API 구현

### DIFF
--- a/src/main/java/com/drop/dropshop/droneCompany/controller/DroneCompanyController.java
+++ b/src/main/java/com/drop/dropshop/droneCompany/controller/DroneCompanyController.java
@@ -3,18 +3,22 @@ package com.drop.dropshop.droneCompany.controller;
 import com.drop.dropshop.droneCompany.dto.DroneCompanyDto;
 import com.drop.dropshop.droneCompany.entity.DroneCompany;
 import com.drop.dropshop.droneCompany.exception.BusinessNumberNotValidException;
+import com.drop.dropshop.droneCompany.response.PagingResponseDetails;
 import com.drop.dropshop.droneCompany.response.ResponseDetails;
 import com.drop.dropshop.droneCompany.service.DroneCompanyService;
 import com.drop.dropshop.droneCompany.util.HttpStatusChangeInt;
 import io.swagger.annotations.ApiOperation;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.Date;
+import java.util.List;
 
 @RestController
 @Slf4j
@@ -27,11 +31,26 @@ public class DroneCompanyController {
 
     @PostMapping("/api/drone-companies")
     @ApiOperation(value = "드론 업체 등록", notes = "관리자가 드론 업체를 등록합니다.")
-    public ResponseEntity<?> createCourse(@RequestBody DroneCompanyDto requestDto) throws BusinessNumberNotValidException {
+    public ResponseEntity<?> createDroneCompany(@RequestBody DroneCompanyDto requestDto) throws BusinessNumberNotValidException {
         DroneCompany droneCompany = droneCompanyService.join(requestDto);
         String path = "/api/drone-companies?id=" + droneCompany.getCompanyId();
         int httpStatus = HttpStatusChangeInt.ChangeStatusCode("CREATED");
         ResponseDetails responseDetails = new ResponseDetails(new Date(), droneCompany, httpStatus, path);
         return new ResponseEntity<>(responseDetails, HttpStatus.CREATED);
+    }
+
+    @GetMapping("/api/drone-companies")
+    @ApiOperation(value = "드론 업체 리스트 조회", notes = "관리자가 드론 업체를 조회합니다.")
+    public ResponseEntity<?> showAllDroneCompany(@PageableDefault(page = 1, size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        Page<DroneCompany> droneCompanyList = droneCompanyService.show(pageable);
+        int httpStatus = HttpStatusChangeInt.ChangeStatusCode("OK");
+        String path = "/api/drone-companies";
+        PagingResponseDetails pagingResponseDetails = new PagingResponseDetails(new Date(),
+                droneCompanyList.getContent(),
+                droneCompanyList.getTotalElements(),
+                droneCompanyList.getPageable().getPageNumber() + 1,
+                droneCompanyList.getPageable().getPageSize(),
+                httpStatus, path);
+        return new ResponseEntity<>(pagingResponseDetails, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/drop/dropshop/droneCompany/controller/DroneCompanyController.java
+++ b/src/main/java/com/drop/dropshop/droneCompany/controller/DroneCompanyController.java
@@ -1,8 +1,10 @@
 package com.drop.dropshop.droneCompany.controller;
 
 import com.drop.dropshop.droneCompany.dto.DroneCompanyDto;
+import com.drop.dropshop.droneCompany.dto.UUIDResponse;
 import com.drop.dropshop.droneCompany.entity.DroneCompany;
 import com.drop.dropshop.droneCompany.exception.BusinessNumberNotValidException;
+import com.drop.dropshop.droneCompany.exception.NoResourceException;
 import com.drop.dropshop.droneCompany.response.PagingResponseDetails;
 import com.drop.dropshop.droneCompany.response.ResponseDetails;
 import com.drop.dropshop.droneCompany.service.DroneCompanyService;
@@ -18,7 +20,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Date;
-import java.util.List;
+import java.util.UUID;
 
 @RestController
 @Slf4j
@@ -52,5 +54,16 @@ public class DroneCompanyController {
                 droneCompanyList.getPageable().getPageSize(),
                 httpStatus, path);
         return new ResponseEntity<>(pagingResponseDetails, HttpStatus.OK);
+    }
+
+    @DeleteMapping("/api/drone-companies/{id}")
+    @ApiOperation(value = "드론 업체 삭제", notes = "관리자가 드론 업체를 삭제합니다.")
+    public ResponseEntity<?> deleteDroneCompany(@PathVariable UUID id) throws NoResourceException {
+        UUID result = droneCompanyService.delete(id);
+        UUIDResponse uuidResponse = new UUIDResponse(result.toString());
+        int httpStatus = HttpStatusChangeInt.ChangeStatusCode("OK");
+        String path = "/api/drone-companies";
+        ResponseDetails responseDetails = new ResponseDetails(new Date(), uuidResponse , httpStatus, path);
+        return new ResponseEntity<>(responseDetails, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/drop/dropshop/droneCompany/dto/UUIDResponse.java
+++ b/src/main/java/com/drop/dropshop/droneCompany/dto/UUIDResponse.java
@@ -1,0 +1,16 @@
+package com.drop.dropshop.droneCompany.dto;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+@RequiredArgsConstructor
+public class UUIDResponse {
+    @ApiModelProperty(example = "uuid")
+    private final String uuid;
+}

--- a/src/main/java/com/drop/dropshop/droneCompany/entity/DroneCompany.java
+++ b/src/main/java/com/drop/dropshop/droneCompany/entity/DroneCompany.java
@@ -35,7 +35,7 @@ public class DroneCompany extends Timestamped {
     private String loginId;
 
     @ApiModelProperty(example = "드론 업체가 로그인 시 사용할 password")
-    @Column(nullable = false, unique = true, length = 20)
+    @Column(nullable = false, length = 20)
     private String loginPassword;
 
     @ApiModelProperty(example = "드론 업체명")

--- a/src/main/java/com/drop/dropshop/droneCompany/exception/ErrorCode.java
+++ b/src/main/java/com/drop/dropshop/droneCompany/exception/ErrorCode.java
@@ -7,7 +7,8 @@ import lombok.Getter;
 @Getter
 public enum ErrorCode {
     BUSINESS_NUMBER_NOT_VALID(400, "BUSINESS NUMBER NOT VALID"),
-    INTER_SERVER_ERROR(500,"INTER SERVER ERROR"),;
+    INTER_SERVER_ERROR(500, "INTER SERVER ERROR"),
+    RESOURCE_NOT_FOUND(404, "RESOURCE NOT FOUND");
 
     private int status;
     private String message;

--- a/src/main/java/com/drop/dropshop/droneCompany/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/drop/dropshop/droneCompany/exception/GlobalExceptionHandler.java
@@ -17,6 +17,13 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
 
+    @ExceptionHandler(NoResourceException.class)
+    public ResponseEntity<ErrorResponse> noResourceException(NoResourceException ex) {
+        log.error("NoResourceException",ex);
+        ErrorResponse response = new ErrorResponse(ex.getErrorCode(), ex.getDetail());
+        return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleException(Exception ex){
         log.error("handleException",ex);

--- a/src/main/java/com/drop/dropshop/droneCompany/exception/NoResourceException.java
+++ b/src/main/java/com/drop/dropshop/droneCompany/exception/NoResourceException.java
@@ -1,0 +1,18 @@
+package com.drop.dropshop.droneCompany.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@Getter
+@ResponseStatus(value = HttpStatus.NOT_FOUND)
+public class NoResourceException extends Exception{
+    private ErrorCode errorCode;
+    private String detail;
+
+    public NoResourceException(String message, ErrorCode errorCode, String detail) {
+        super(message);
+        this.errorCode = errorCode;
+        this.detail = detail;
+    }
+}

--- a/src/main/java/com/drop/dropshop/droneCompany/repository/DroneCompanyRepository.java
+++ b/src/main/java/com/drop/dropshop/droneCompany/repository/DroneCompanyRepository.java
@@ -4,9 +4,14 @@ import com.drop.dropshop.droneCompany.entity.DroneCompany;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
+import java.util.UUID;
 
 public interface DroneCompanyRepository extends JpaRepository<DroneCompany, Long> {
     Optional<DroneCompany> findByBuisenessNumber(String buisenessNumber);
 
     Optional<DroneCompany> findByLoginId(String loginId);
+
+    void deleteByCompanyId(UUID companyId);
+
+    Optional<DroneCompany> findByCompanyId(UUID companyId);
 }

--- a/src/main/java/com/drop/dropshop/droneCompany/response/PagingResponseDetails.java
+++ b/src/main/java/com/drop/dropshop/droneCompany/response/PagingResponseDetails.java
@@ -1,0 +1,18 @@
+package com.drop.dropshop.droneCompany.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Date;
+
+@Getter
+@AllArgsConstructor
+public class PagingResponseDetails {
+    private Date timestamp;
+    private Object data;
+    private Long total;
+    private int currentPage;
+    private int currentPageSize;
+    private int httpStatus;
+    private String path;
+}

--- a/src/main/java/com/drop/dropshop/droneCompany/service/DroneCompanyService.java
+++ b/src/main/java/com/drop/dropshop/droneCompany/service/DroneCompanyService.java
@@ -4,6 +4,7 @@ import com.drop.dropshop.droneCompany.dto.DroneCompanyDto;
 import com.drop.dropshop.droneCompany.entity.DroneCompany;
 import com.drop.dropshop.droneCompany.exception.BusinessNumberNotValidException;
 import com.drop.dropshop.droneCompany.exception.ErrorCode;
+import com.drop.dropshop.droneCompany.exception.NoResourceException;
 import com.drop.dropshop.droneCompany.repository.DroneCompanyRepository;
 import okhttp3.*;
 import org.json.JSONObject;
@@ -13,8 +14,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.config.PageableHandlerMethodArgumentResolverCustomizer;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Service
@@ -87,6 +90,10 @@ public class DroneCompanyService {
         return validateDuplicateId(newId);
     }
 
+    public Optional<DroneCompany> findByCompanyId(UUID companyId) {
+        return droneCompanyRepository.findByCompanyId(companyId);
+    }
+
     /**
      * 드론 업체 등록
      */
@@ -119,5 +126,19 @@ public class DroneCompanyService {
      */
     public Page<DroneCompany> show(Pageable pageable) {
         return droneCompanyRepository.findAll(pageable);
+    }
+
+    /**
+     * 드론 업체 삭제
+     * company Id 를 이용하여 삭제합니다.
+     */
+    public UUID delete(UUID companyId) throws NoResourceException {
+        if (findByCompanyId(companyId).isEmpty()) {
+            String errorMessage = "삭제 요청 받은 Company Id : " + companyId;
+            throw new NoResourceException("삭제 실패", ErrorCode.RESOURCE_NOT_FOUND, errorMessage);
+        }
+
+        droneCompanyRepository.deleteByCompanyId(companyId);
+        return companyId;
     }
 }

--- a/src/main/java/com/drop/dropshop/droneCompany/service/DroneCompanyService.java
+++ b/src/main/java/com/drop/dropshop/droneCompany/service/DroneCompanyService.java
@@ -7,10 +7,14 @@ import com.drop.dropshop.droneCompany.exception.ErrorCode;
 import com.drop.dropshop.droneCompany.repository.DroneCompanyRepository;
 import okhttp3.*;
 import org.json.JSONObject;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.config.PageableHandlerMethodArgumentResolverCustomizer;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
 import java.io.IOException;
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -40,7 +44,6 @@ public class DroneCompanyService {
         try {
             Response response = client.newCall(request).execute();
             String responseBody = response.body().string();
-            System.out.println(responseBody);
             JSONObject jsonObject = new JSONObject(responseBody);
             if (jsonObject.has("match_cnt")) {
                 return true;
@@ -109,5 +112,12 @@ public class DroneCompanyService {
         return droneCompany;
     }
 
-
+    /**
+     * 드론 업체 조회
+     * 등록 일시를 기준으로 정렬하도록 하였습니다.
+     * 기본값 : page = 1, pageSize = 10, sort = createAt DESC
+     */
+    public Page<DroneCompany> show(Pageable pageable) {
+        return droneCompanyRepository.findAll(pageable);
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,11 @@ spring:
   mvc:
     pathmatch:
       matching-strategy: ant_path_matcher
+  data:
+    web:
+      pageable:
+        default-page-size: 10
+        one-indexed-parameters: true
 
 logging.level:
   org.hibernate.SQL: debug

--- a/src/test/java/com/drop/dropshop/droneCompany/service/DroneCompanyServiceTest.java
+++ b/src/test/java/com/drop/dropshop/droneCompany/service/DroneCompanyServiceTest.java
@@ -3,6 +3,7 @@ package com.drop.dropshop.droneCompany.service;
 import com.drop.dropshop.droneCompany.dto.DroneCompanyDto;
 import com.drop.dropshop.droneCompany.entity.DroneCompany;
 import com.drop.dropshop.droneCompany.exception.BusinessNumberNotValidException;
+import com.drop.dropshop.droneCompany.exception.NoResourceException;
 import com.drop.dropshop.droneCompany.repository.DroneCompanyRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,6 +15,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -72,5 +75,17 @@ class DroneCompanyServiceTest {
         Page<DroneCompany> droneCompanies = droneCompanyService.show(pageable);
         droneCompany = droneCompanies.getContent().get(0);
         assertEquals(droneCompanyDto.getCompanyName(), droneCompany.getCompanyName());
+    }
+
+    @Test
+    void 드론_업체_삭제() throws BusinessNumberNotValidException, NoResourceException {
+        DroneCompanyDto droneCompanyDto = new DroneCompanyDto(
+                "11드론",
+                "0313327312",
+                "3098106517"
+        );
+        DroneCompany droneCompany = droneCompanyService.join(droneCompanyDto);
+        UUID result = droneCompanyService.delete(droneCompany.getCompanyId());
+        assertEquals(droneCompany.getCompanyId(), result);
     }
 }

--- a/src/test/java/com/drop/dropshop/droneCompany/service/DroneCompanyServiceTest.java
+++ b/src/test/java/com/drop/dropshop/droneCompany/service/DroneCompanyServiceTest.java
@@ -8,11 +8,17 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import static org.assertj.core.api.Assertions.assertThat;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
+@Transactional
 class DroneCompanyServiceTest {
     @Autowired
     private DroneCompanyRepository droneCompanyRepository;
@@ -51,6 +57,20 @@ class DroneCompanyServiceTest {
                 "3098106517"
         );
         DroneCompany droneCompany = droneCompanyService.join(droneCompanyDto);
+        assertEquals(droneCompanyDto.getCompanyName(), droneCompany.getCompanyName());
+    }
+
+    @Test
+    void 드론_업체_조회() throws BusinessNumberNotValidException {
+        DroneCompanyDto droneCompanyDto = new DroneCompanyDto(
+                "11드론",
+                "0313327312",
+                "3098106517"
+        );
+        DroneCompany droneCompany = droneCompanyService.join(droneCompanyDto);
+        Pageable pageable =  PageRequest.of(0, 10, Sort.by("createdAt").descending());
+        Page<DroneCompany> droneCompanies = droneCompanyService.show(pageable);
+        droneCompany = droneCompanies.getContent().get(0);
         assertEquals(droneCompanyDto.getCompanyName(), droneCompany.getCompanyName());
     }
 }


### PR DESCRIPTION
**구현 내용**
* 드론 업체 삭제 API 를 개발하였습니다.
* 요청 받은 id 로 드론 업체 조회 후 업체가 존재하지 않다면 NOT_RESOURCE_FOUND 에러 응답을 내리고 
* 업체가 존재한다면 삭제 후 UUID 응답 객체를 만들어 응답을 내립니다.
→ response http status code 로 204 (NO_CONTENT)를 내리고 싶었지만 이 상태값을 쓰는 경우 응답에 엔티티를 포함할 수 없어 200 OK 로 진행하였습니다.
------------
**IntelliJ 에서 요청 시** 
```
OkHttpClient client = new OkHttpClient().newBuilder().build();
MediaType mediaType = MediaType.parse("text/plain");
RequestBody body = RequestBody.create(mediaType, "");
Request request = new Request.Builder()
  .url("127.0.0.1:8080/api/drone-companies/cedc38fb-d34f-426b-8d43-24b6fc53ed0e")
  .method("DELETE", body)
  .build();
Response response = client.newCall(request).execute();
```
----------------
**postman 사용 시** 
DELETE 127.0.0.1:8080/api/drone-companies/{comany_id}

----------------
**API 테스트 - 삭제 성공** 
<img width="879" alt="스크린샷 2022-06-08 오전 11 56 25" src="https://user-images.githubusercontent.com/84092014/172522635-c0f1b3a7-8463-47b1-ade2-9e541a2a3a00.png">

---------------

**API 테스트 - 드론 업체 찾을 수 없음** 
<img width="877" alt="스크린샷 2022-06-08 오후 12 05 11" src="https://user-images.githubusercontent.com/84092014/172522864-1dc82c77-6a86-42ff-922c-abf996a5289e.png">

----------------

**Junit 테스트 결과 화면**
<img width="748" alt="스크린샷 2022-06-08 오전 11 51 57" src="https://user-images.githubusercontent.com/84092014/172522682-8b3eb1e3-630f-4a48-9c78-babe4b06a77d.png">


